### PR TITLE
Clojure constructors variations

### DIFF
--- a/src/clojure_applied/ch1/apollo.clj
+++ b/src/clojure_applied/ch1/apollo.clj
@@ -69,3 +69,21 @@
                 :lm-name "Eagle"
                 :orbits 30
                 :evas 2))
+
+;; Sometimes it may be needed to derive values expected by a constructor from a function
+;; Let's assume that the Planet entity constructor is expecting an orbital-eccentricity
+;; derived from a vector
+(defn euclidian-form [ecc-vector]
+  ;; For the sake of simplicity, the euclidian-form will just multiply each vector element
+  ;; by itself
+  (map #(* % %) ecc-vector))
+
+;; The Planet entity is expecting the #orbital-eccentricity as the last parameter, which is
+;; to be derived from a vector provided to the constructor using the euclidian-form function
+;; defined earlier
+(defrecord Planet [name moons volume mass aphelion perihelion orbital-eccentricity])
+
+(defn make-Planet
+  "Make a planet from field values and an eccentricity vector"
+  [name moons volume mass aphelion perihelion ecc-vector]
+  (->Planet name moons volume mass aphelion perihelion (euclidian-form ecc-vector)))

--- a/src/clojure_applied/ch1/image.clj
+++ b/src/clojure_applied/ch1/image.clj
@@ -1,0 +1,16 @@
+(ns ch1.image
+  (:require [clojure.java.io :as io])
+  (:import [javax.imageio ImageIO]
+           [java.awt.image BufferedImage]))
+
+;; Sometimes side-effects are unavoidable. For example, when constructing an entity
+;; with an associated-image retrieved from I/O like in the following
+(defrecord PlanetImage [src ^BufferedImage contents])
+
+;; In this case, using a constructor help us isolate the side-effects from the rest
+;; of the code
+(defn make-planet-image
+  "Make a PlanetImage which may throw an IOException"
+  [src]
+  (with-open [img (ImageIO/read (io/input-stream src))]
+    (->PlanetImage src img)))


### PR DESCRIPTION
This PR explains the usage of Clojure constructors as a way of building new entities.
It covers : 

- the usage of derived values (pre-calculated with a function) as parameters fed to the factory function

- the usage of constructors as a way to isolate side-effects when initializing entities