### PR TITLE
Implement clojure way of defining default entities (zero quantity values, empty container etc.)

### DIFF
--- a/src/clojure_applied/ch1/money.clj
+++ b/src/clojure_applied/ch1/money.clj
@@ -69,3 +69,14 @@
 
 ;; When destructuring by position, values likely to be used are placed earlier in the argument
 ;; list which is constraining
+
+;; Sometimes, we may be tempted to represent zero quantity or any empty container with a function
+;; returning the same value when called like so
+(defn new-money
+  "$0.00 usd"
+  []
+  (->Money 0 :usd))
+
+;; It is easier though, to take advantage of Clojure's immutable values and to, instead, return
+;; a "value" rather than a function
+(def zero-dollars (->Money 0 :usd))


### PR DESCRIPTION
This PR shows Clojure's way of defining zero quantity entities or empty container values. The best practice favors, for efficiency, the use of Clojure's immutable values instead of defining functions which would return the exact same value for each call.