### PR TITLE
Clj multimethods protocols

### DIFF
--- a/src/ch1/convert.clj
+++ b/src/ch1/convert.clj
@@ -1,0 +1,41 @@
+(ns ch1.convert
+  (:require [ch1.validate]
+            [ch1.money :refer (+$ zero-dollars)]))
+
+;; We want to be able to combine and calculate the cost of an ingredient from 2 different recipes
+;; but which may be expressed with different units for example. We then have to convert them to the same
+;; unit before being able to make the calculation.
+
+;; Using value-based (the values here are the units) dispatch with multi-methods, we will use a
+;; dispatch function returning the couple [unit1 unit2], unit1 being the ingredient unit (source) to be
+;; converted to unit2 (target). Based on this couple "value" returned by the dispatch function, we then
+;; choose the right method implementation to dispatch the call to.
+(defmulti convert
+          "Converts quantity from unit1 to unit2, matching on the value of [unit1, unit2]"
+          (fn [unit1 unit2 quantity] [unit1 unit2]))
+
+;; This is the implementation for converting from :lb to :oz, matched with the couple value [:lb :oz]
+(defmethod convert [:lb :oz]
+  [_ _ lb]
+  (* lb 16))
+
+;; This is the implementation for converting from :oz to :lb, matched with the couple value [:oz :lb]
+(defmethod convert [:oz :lb]
+  [_ _ oz]
+  (/ oz 16))
+
+;; This is a fallback mechanism covering the case where the units are the same, hence returning the quantity
+;; without any conversion, or throwing an exception when the particular couple "value" [unit1 unit2] does not
+;; have a matching method implementation
+(defmethod convert :default
+  [u1 u2 quantity]
+  (if (= u1 u2)
+    quantity
+    (assert false (str "Unknown unit conversion from " u1 " to " u2))))
+
+;; This is a utility method allowing the combination of two (2) ingredients expressed with different units
+;; using the multimethod convert implemented above
+(defn ingredient+
+  "Add two ingredients into a single ingredient, converting their quantities with unit conversion if needed"
+  [{unit1 :unit quantity1 :quantity :as ingredient1} {unit2 :unit quantity2 :quantity}]
+  (assoc ingredient1 :quantity (+ quantity1 (convert unit2 unit1 quantity2))))

--- a/src/ch1/multimethods.clj
+++ b/src/ch1/multimethods.clj
@@ -1,0 +1,44 @@
+(ns ch1.multimethods
+  (:require [ch1.validate]
+            [ch1.money :refer (+$ zero-dollars)])
+  (:import [ch1.validate Recipe Ingredient]))
+
+;; We extend the recipe-manager domain to accommodate the multimethod use-case
+;; illustration by adding a Store
+(defrecord Store [,,,])
+
+;; and a convenient (hypothetical) function that can look up the cost of an
+;; ingredient in a particular store
+(def cost-of [store ingredient],,,)
+
+;; Then we define the 'multidispatch' by specifying the 'dispatch function'. This function
+;; is at the core of the multimethod machinery since it will be called to produce a value
+;; called the 'dispatch value'.
+;; The 'dispatch value' will then be used to select the particular method implementation
+;; to which the call should be dispatched
+(defmulti cost
+          "This macro defines a 'dispatch function' which returns the 'type' of a domain object
+          (either Recipe or Ingredient) and will allow the multimethod machinery to select
+          the right implementation for the cost calculation based on this domain object type."
+          (fn [entity store]
+            (class entity)))                                ;; returns the domain object class
+
+;; We finally define cost-calculation method implementations for each 'dispatch value' for
+;; which we would like to be able to calculate costs. The method implementation must
+;; have the same signature as the 'dispatch function' since their inputs will be mapped to
+;; those of the 'dispatch function' to return the 'dispatch value' first, and then to invoke
+;; the correct implementation.
+
+;; We define the cost-calculation method implementation for the Recipe domain object, hence the Recipe
+;; dispatch value of 'Recipe' in the defmethod macro header in the following form.
+(defmethod cost Recipe
+  [recipe store]                                            ;; Same signature as the dispatch function here
+  ;; Note that this implementation is also dispatching to the cost-calculation method implementation
+  ;; of the Ingredient domain object when mapping on '#(cost store %)' each recipe ingredients.
+  (reduce +$ zero-dollars (map #(cost store %) (:ingredients recipe))))
+
+;; We define the cost-calculation method implementation for the Ingredient domain object, hence the Ingredient
+;; dispatch value of 'Ingredient' in the defmethod macro header in the following form.
+(defmethod cost Ingredient
+  [ingredient store]                                        ;; Same signature as the dispatch function here
+  (cost-of store ingredient))

--- a/src/ch1/protocols.clj
+++ b/src/ch1/protocols.clj
@@ -1,0 +1,29 @@
+(ns ch1.protocols
+  (:require [ch1.validate]
+            [ch1.money :refer (+$ zero-dollars)])
+  (:import [ch1.validate Recipe Ingredient]))
+
+;; We extend the recipe-manager domain to accommodate the protocol use-case
+;; illustration by adding a Store
+(defrecord Store [,,,])
+
+;; and a convenient (hypothetical) function that can look up the cost of an
+;; ingredient in a particular store
+(def cost-of [store ingredient],,,)
+
+
+;; we then define the Protocol which is a 'contract' grouping the functions
+;; that has to be implemented by any component interested in complying with
+;; the terms of the contract
+(defprotocol Cost
+  (cost [entity store]))
+
+;; we finally extend the types by providing, for each, implementations to the methods
+;; defined in the protocol they are extending
+(extend-protocol Cost
+  Recipe
+  (cost [recipe store]
+    (reduce +$ zero-dollars (map #(cost % store) (:ingredients recipe))))
+  Ingredient
+  (cost [ingredient store]
+    (cost-of store ingredient)))


### PR DESCRIPTION
This PR deals with the Clojure way of defining generic operations for domain entities so as to decouple the business logic from the entities these logics applies to.