### PR TITLE
Clojure reducers

### DIFF
--- a/src/ch3/orbital.clj
+++ b/src/ch3/orbital.clj
@@ -81,3 +81,35 @@
   "This function returns a list"
   [planets star]
   (into () (orbital-period-transformation star) planets))
+
+
+
+;; Reducing a collection consists in repeatedly applying a function to an accumulated value and the next item
+;; in the collection, hence consumming the collection and giving a value as a final result.
+;; A optional value, also known as a 'seed' can be provided as the first initial value of the accumulator.
+;; Sometimes, like in the case of the 'into' function, we get back a collection as a final result instead of a
+;; single value : 'into' is a specialization of reduce
+
+;; as an example, let's say that we would like to compute the number of moon of our solar system.
+;; It involves :
+;;   - getting the planets collection as input
+;;   - extracting for each planet its moon count (hence a tranformation operation via map)
+;;   - and combining each planets moon count (hence a reduction operation via +)
+(defn total-moons
+  "Computes the total number of moons of the solar system"
+  [planets]
+  (reduce + 0 (map #(:moons %) planets)))
+   ;; or with a more idiomatic version of the map portion
+   ;; (reduce + 0 (map :moons planets))
+
+;; We can also achieve the same result using a transducer. As seen earlier, transducers are an elaboration on the
+;; idea of reducers with the added-value of having transformations abstracted away from the implementation details of the
+;; input and output. It means that in the previous example, we could have abstracted away the transformation part (via map)
+;; which could then be reused in other contexts.
+(def xf-moon-count
+  (map :moons))
+
+(defn total-moons-transduced
+  "Computes the total number of moons of the solar system using a transducer"
+  [planets]
+  (transduce xf-moon-count + 0 planets))

--- a/src/ch3/orbital.clj
+++ b/src/ch3/orbital.clj
@@ -113,3 +113,19 @@
   "Computes the total number of moons of the solar system using a transducer"
   [planets]
   (transduce xf-moon-count + 0 planets))
+
+;; Sometimes when reducing over a collection, we may want to stop the reduction early on in the process i.e without consuming
+;; every element in the collection. In that case, we can use the 'reduced' function, which takes as argument the value
+;; to be returned as the result of the reduction as illustrated in the following example :
+(defn find-planet
+  "Reduces over a collection but stops early on when it finds a planet whose name is the same as the name provided as argument
+   to the function"
+  [planets pname]
+  (reduce
+    (fn [_ planet] 
+      (when (= (:name planet) pname)
+        (reduced planet)))
+    planets))
+
+;; we can draw a parallel between 'reduced' and the use of 'break' in java with the addition that the former, instead of
+;; just stopping the process early, also returns a value/result. Let's say that 'reduced' is 'break on steroids' ...


### PR DESCRIPTION
This PR illustrates the use of Clojure `reducer` functions as a way to apply a function over successive elements of a collection and accumulate the result in order to get a single value returned from the reduction.