### PR TITLE
Illustrate the use of 'sort' and 'sort-by' for sorting collections

### DIFF
--- a/src/ch3/fn.clj
+++ b/src/ch3/fn.clj
@@ -57,3 +57,58 @@
 ;; take-while and the second element would be the result of applying drop-while to the initial collection.
 (split-with pos? coll)
 ;; => [(10 9 8 7 6 5 4 3 2 1) (0 -1 -2)]
+
+
+;; Talking about sorting, the most basic function for sorting a collection is 'sort' which, given a comparator function, allows defining a
+;; custom sorting logic. Otherwise, it will just use the 'compare' function.
+
+;; Let's say for example that we would like to sort the first 5 planets name : the sorting logic i.e the comparator function would then
+;; be the planet's name
+;; (take 5 (sort (map :name planets)))
+
+;; sometimes though, we would like to have the original entities sorted instead of just one attribute (here name). In this case, we use the
+;; 'sort-by' function and provide it with the key (the object/entity attribute) with which to sort the entities and an optional comparator if
+;; there is a need to define a custom logic for sorting with the chosen key.
+
+;; let's say then that instead of retrieving the name of the first 5 planets, we would like to retrieve the 5 planets themselves :
+;; (take 5 (sort-by :name planets))
+;=>
+;({:name "Earth", :moons ["moon"], :orbit-days 365.2564}
+; {:name "Jupiter", :moons ["io" "europa" "ganymede" "callisto"]}
+; {:name "Mars", :orbit-days 686.93}
+; {:name "Mercury", :orbit-days 87.969}
+; {:name "Neptune", :moons ["triton"], :orbit-days 60148.35})
+
+;; as a last illustration of the sorting mechanism, let's say we would like to define a function allowing us to retrieve the n smallest
+;; planets, n being in this case a parameter.
+;; The :volume is then the attribute or key function on which the comparison will be held.
+(defn smallest-n
+  "Retrieve the n smallest planets"
+  [planets n]
+  (->> planets
+       (sort-by :volume)                                    ;; we first sort the planets by volume in ascending order
+       (take n)))                                           ;; then we take the n first planets of the previous sorting step
+
+;; with the following data (with fake volume data obviously) :
+;(def planets
+;  [{:name "Earth", :moons ["moon"], :orbit-days 365.2564 :volume 2531545}
+;   {:name "Jupiter", :moons ["io" "europa" "ganymede" "callisto"] :volume 1231545}
+;   {:name "Mars", :orbit-days 686.93 :volume 9231545}
+;   {:name "Mercury", :orbit-days 87.969 :volume 231545}
+;   {:name "Neptune", :moons ["triton"], :orbit-days 60148.35 :volume 431231545}
+;   {:name "Pluto", :moons ["charon" "styx" "nix" "kerberos" "hydra"] :volume 150231545}
+;   {:name "Saturn", :moons ["titan"], :orbit-days 10755.7 :volume 431231545}
+;   {:name "Uranus", :moons ["titania" "oberon"], :orbit-days 30688.5 :volume 131545}
+;   {:name "Venus", :orbit-days 224.7 :volume 505431}])
+
+;; the 6 smallest planets would be :
+; (smallest-n planets 6)
+
+;; which would return :
+;=>
+;({:name "Uranus", :moons ["titania" "oberon"], :orbit-days 30688.5, :volume 131545}
+;  {:name "Mercury", :orbit-days 87.969, :volume 231545}
+;  {:name "Venus", :orbit-days 224.7, :volume 505431}
+;  {:name "Jupiter", :moons ["io" "europa" "ganymede" "callisto"], :volume 1231545}
+;  {:name "Earth", :moons ["moon"], :orbit-days 365.2564, :volume 2531545}
+;  {:name "Mars", :orbit-days 686.93, :volume 9231545})


### PR DESCRIPTION
This PR illustrates the use of `sort` and `sort-by` for sorting collections in Clojure.