### PR TITLE
Clj state identity

### DIFF
--- a/src/ch4/single.clj
+++ b/src/ch4/single.clj
@@ -168,3 +168,27 @@
 ;; There is a fourth reference type that is different from the (3) we have seen so far : `Var`s.
 ;; `Var` differs from the other reference types in that their state is not managed in time. Rather, they provide a namespace-scoped identity
 ;; that can be `rebound` to have a different value on a `per-thread` basis.
+
+
+;; Manipulating `Reference type`s
+;; There are 3 main operations for manipulating reference type values/state and for each, a corresponding function. Note that, as seen with
+;; the Unified Update Model, these function calls have a `consistent` syntax and follow the same `pattern` :
+;;  - Identity Initialization with the correct `reference type` via a `creation function`
+;;    Pattern : (create-fn container)
+;;  - Identity value update with an `update function` as seen with the `Unified Update Model` seen earlier
+;;    Pattern : (update-fn container data-fn & args)
+;;  - Identity value reset with a `set function`
+;;    Pattern : (set-fn container new-val)
+
+;; `Reference type`   |   `create-fn`   |   `update-fn`           |    `set-fn`             |
+;; ==========================================================================================
+;;  Atom              |   (atom ...)    |   (swap! ...)           |    (reset! ...)         |
+;;  Ref               |   (ref ...)     |   (alter ...)           |    (ref-set ...)        |
+;;                    |                 |   (commute ...)         |                         |
+;;  Var               |   (def ...)     |   (alter-var-root ...)  |    (var-set ...)        |
+;;  Agent             |   (agent ...)   |   (send ...)            |    (restart-agent ...)  |
+;;                    |                 |   (send-off ...)        |                         |
+
+
+;; In the end, the choice for a concurrent implementation consists in reflecting and deciding what information to manage and what information
+;; to leave unmanaged.

--- a/src/ch4/single.clj
+++ b/src/ch4/single.clj
@@ -192,3 +192,23 @@
 
 ;; In the end, the choice for a concurrent implementation consists in reflecting and deciding what information to manage and what information
 ;; to leave unmanaged.
+
+
+
+
+;; MANAGING UPDATES WITH ATOM
+;; Let's walk through an example : a grocery store.
+;; In its simplest form, shopping only consists in having a list of items to be bought and a person (a thread) going to the store to get the items.
+
+(defn go-shopping-naive
+  "Returns a cart containing the list of bought items"
+  [shopping-list]
+  (loop [[item & items] shopping-list
+         cart []]
+    (if item
+      (recur items (conj cart item))
+      cart)))
+
+;; This scenario does not involve state management because we only have one `thread` (person) interacting with the program. Furthermore, in the example,
+;; the items rest on a infinite shelf and the program only consists in moving items from one list to another.
+;; In a more elaborate version though (and in the real world), we would probably have a kind of `store inventory` containing the store `available` items.

--- a/src/ch4/single.clj
+++ b/src/ch4/single.clj
@@ -150,3 +150,17 @@
 ;; ASYNCHRONOUS
 ;; Asynchronous operations, instead of blocking/waiting for an exclusive access to a context, spins off another thread to get
 ;; a different context of its own for the execution. It does not block the caller's thread.
+
+
+
+
+;; TOOLS FOR MANAGING CHANGES a.k.a Reference types
+;; The two (2) concepts `coordination` and `synchronization` and their `duals` let us define exactly the type of concurrent operations
+;; that we would like to achieve, hence the `reference type` to be used as well. Considering the duals then, we have 3 of the 4 kinds
+;; of `reference type` :
+;;   - Coordinated and Synchronous : REFS reference type
+;;   - Coordinated and Asynchronous : this one does not exist in Clojure since it is only interested in addressing in-memory concurrency
+;; whereas `Coordinated and asynchronous` semantics is more common in distributed systems where changes are only guaranteed to merge
+;; into a unified model over time and potentially spanning over multiple systems beyond the local in-process system.
+;;   - Uncoordinated and Synchronous : ATOM reference type
+;;   - Uncoordinated and Asynchronous : AGENT reference type

--- a/src/ch4/single.clj
+++ b/src/ch4/single.clj
@@ -164,3 +164,7 @@
 ;; into a unified model over time and potentially spanning over multiple systems beyond the local in-process system.
 ;;   - Uncoordinated and Synchronous : ATOM reference type
 ;;   - Uncoordinated and Asynchronous : AGENT reference type
+
+;; There is a fourth reference type that is different from the (3) we have seen so far : `Var`s.
+;; `Var` differs from the other reference types in that their state is not managed in time. Rather, they provide a namespace-scoped identity
+;; that can be `rebound` to have a different value on a `per-thread` basis.

--- a/src/ch4/single.clj
+++ b/src/ch4/single.clj
@@ -1,0 +1,57 @@
+(ns ch4.single)
+
+;; Now that we have everything ready under our belt to define entities, collections and functions
+;; for manipulating them, we now have to think about how all these things relate to each other
+;; during the application execution especially in regard to multiple execution threads accessing
+;; and updating them.
+
+;; MODELING CHANGE
+;; first of all, it is important to see how `change` is approached in two (2) of the mostly used/known
+;; programming paradigm today :
+;;   - Object-oriented programming a.k.a OOP
+;;   - Functional programming a.k.a FP (which Clojure is part of)
+
+;; in OOP, we are used to approaching change in terms of `mutability`. The data structures involved
+;; are themselves `mutable` meaning they can be `modified` and incidentally we tend to apply changes
+;; to entities `in place` i.e directly because well, we can. This approach although simple, becomes
+;; radically complex when multiple execution threads are involved. In fact, managing changes in
+;; this case is about coordinating changes(update), access(read) to these shared data among the
+;; execution threads.
+;; Unfortunately, the tools available today on the platform to deal with these change management
+;; are rather low-level and their use often error-prone, think use of `locks` among other things.
+;; It often leads to a lot of ceremony and complexity for programmers especially when considering
+;; that these are `not` problems related to the domain but rather code infrastructure which should
+;; be handled by the paradigm/platform/framework allowing the developer or programmer to focus on
+;; solving the real domain problem at hand.
+;; Another consequence is that managing changes this way is a `destructive` process in that we only
+;; retrieve the result of the update function which is the most up-to-date value of the data structure
+;; as of `now`. There is no way of knowing the value or set of values that may have been assigned to
+;; the data structure prior to the current one.
+
+
+
+;; On the other hand, in FP unlike in OOP, the approach lean towards `immutability` where data structures
+;; are `immutable` and functions for manipulating/changing them creates new data structures when applying
+;; those functions instead of changing the data in place. Even though this approach may be counter-intuitive,
+;; since we may be confused into thinking that it involves a lot of copying, it is actually quite the opposite.
+;; In fact in FP, creating new data from the ones to be modified make use of a process called `structural sharing`
+;; or `data sharing`.
+;; In this approach, instead of copying the whole data to be modified, we reuse the existing data structure
+;; and only add/remove the relevant `parts` which are the resultant of applying the modifying function, with
+;; the use of `references` pointing at each other to combine and form new data structures.
+;; There is no real removal or adding per se, it only consists in creating `references` pointing at different
+;; locations in the involved data structures :
+
+;; let's consider a linked-list for example. When creating the list, we are provided with a new `reference` pointing
+;; to the `head` of the list, let's call it (X). If we want the removal of this linked list head element for
+;; example, we create a `totally new` reference (Y) which, instead of a real removal of the linked list head, will
+;; just point to the element of the linked-list pointed to by (X), right after the `head`. The original
+;; linked-listed pointed to by (X) is still available and it shares a subpart of its structure with the new
+;; linked-listed pointed to by (Y).
+
+;; As a consequence, entities supported and implemented with `immutable` data structures act as containers
+;; of a series of values corresponding to the different `states` (represented by the `references`) the data
+;; structure has been through after update function has been applied one more multiple times. A set of discrete
+;; values, a series of snapshots as if it were its `history` allowing to go back at a certain point in time
+;; to a particular `state`, at will. Hence this `non-destructive` approach eases the process of changing state
+;; because of the `immutability` nature of the data structure involved.

--- a/src/ch4/single.clj
+++ b/src/ch4/single.clj
@@ -78,8 +78,10 @@
 ;; current value to compute the reference's new value (state).
 ;; Depending on the problem at hand, the `reference` type may vary, but the syntax and approach to handling the update
 ;; remains the same and always follows the same pattern.
-;;
+
+
 ;; (update-fn container-ref data-fn &args)
+
 
 ;; `update-fn` triggers the update process and is solely determined by the type of `reference` (atom, ref, var, agent)
 ;; whose value is to be updated.
@@ -89,3 +91,21 @@
 ;; `update-fn` call in its `args` argument.
 ;; `args` (optional) are arguments provided to the `data-fn` in addition to the current value of the `container-ref` to
 ;; process the value to be set as its new value.
+
+
+;; There are two (2) dimensions involved when choosing the `right` reference type for the unified update model
+;;  - a notion of `scope` defining to which extent the change has to be applied
+;;  - a notion of `temporality` defining when the change has to be applied
+
+
+;; ATOMIC SCOPE
+;; It occurs when a single `standalone` value is changed `independently` of all other stateful references within the system.
+;; It then does not require `coordination` because of this independence.
+;; The way it works is that given an identity and an update function, the latter is applied to the current value of the
+;; former, eventually with arguments (seen earlier) to calculate the new value of the identity. If everything goes well,
+;; this newly processed value will replace the current identity value.
+;; Problem occur though when multiple threads try to update the same identity in the same time. The mechanism then reorders
+;; the updates so that only one at a time occurs. That is, if a thread is on the verge of committing the identity newly
+;; created value but a second thread has updated it in the same time, then the first thread has to renew/retry the overall
+;; process of calculating the identity new value but this time taking into account the current value of the identity as
+;; the newly committed value set by the second thread.

--- a/src/ch4/single.clj
+++ b/src/ch4/single.clj
@@ -68,3 +68,15 @@
 ;;
 ;; a `state` is a snapshot of an `identity's` value and it represents its value at that particular time. There is
 ;; a notion of temporality involved here.
+
+
+;; UNIFIED UPDATE MODEL
+;; Clojure's approach to modelling and managing `values that change` is opinionated and to some extent, is really simple in
+;; essence. In fact, it relies on a concept called the `unified update model` which is a generic `form pattern`
+;; involving the `reference` which represents the `identity` as we have seen, a function for updating the identity's
+;; state called the `data function` and `arguments` used by the data function in conjunction with the reference's
+;; current value to compute the reference's new value (state).
+;; Depending on the problem at hand, the `reference` type may vary, but the syntax and approach to handling the update
+;; remains the same and always follows the same pattern.
+
+;; (update-fn container-ref data-fn &args)

--- a/src/ch4/single.clj
+++ b/src/ch4/single.clj
@@ -212,3 +212,24 @@
 ;; This scenario does not involve state management because we only have one `thread` (person) interacting with the program. Furthermore, in the example,
 ;; the items rest on a infinite shelf and the program only consists in moving items from one list to another.
 ;; In a more elaborate version though (and in the real world), we would probably have a kind of `store inventory` containing the store `available` items.
+
+;; Our hypothetical inventory would be represented by a map of entities to quantities. It can potentially be accessed by multiple threads (person) so
+;; we have to ensure that any changes that we apply to the inventory become available to the other threads via the use of a reference type.
+;; For choosing the reference type, we have to go through a funneling process where we :
+;;  - determine the number of entities involved in order to know whether we need `coordination` or not
+;;  - determine whether changes are to be applied immediately or at some point in the future to know whether we need a `synchronous` operation or an
+;; `asynchronous` one.
+;;
+;; So here are the questions that can help us in the decision-making related to the choice of the reference type :
+;;  - are multiple entities involved ?
+;; the answer is NO since we only have to manage an inventory. It also means that we do not need coordinated reference type, so we get rid of `refs` in
+;; our choices because what we need is an `uncoordinated` reference type.
+;;
+;;  - are the changes to happen right away or can they happen at some point in the future ?
+;; the answer is, the changes have to happen `right away` in order for the other threads to see consistent data and not partially updated ones. It means
+;; that the reference type that we have to use is a `synchronous` one.
+;;
+;; in the end then, we need both a :
+;;  - `uncoordinated`
+;;  - `synchronous`
+;; reference type which according to the reference type classification we had earlier corresponds to `atom`s.

--- a/src/ch4/single.clj
+++ b/src/ch4/single.clj
@@ -46,7 +46,7 @@
 ;; to the `head` of the list, let's call it (X). If we want the removal of this linked list head element for
 ;; example, we create a `totally new` reference (Y) which, instead of a real removal of the linked list head, will
 ;; just point to the element of the linked-list pointed to by (X), right after the `head`. The original
-;; linked-listed pointed to by (X) is still available and it shares a subpart of its structure with the new
+;; linked-listed pointed to by (X) is still available and it shares a sub-part of its structure with the new
 ;; linked-listed pointed to by (Y).
 
 ;; As a consequence, entities supported and implemented with `immutable` data structures act as containers
@@ -107,7 +107,7 @@
 ;; The way it works is that given an identity and an update function, the latter is applied to the current value of the
 ;; former, eventually with arguments (seen earlier) to calculate the new value of the identity. If everything goes well,
 ;; this newly processed value will replace the current identity value.
-;; Problem occur though when multiple threads try to update the same identity in the same time. The mechanism then reorders
+;; Problem occurs though when multiple threads try to update the same identity at the same time. The mechanism then reorders
 ;; the updates so that only one at a time occurs. That is, if a thread is on the verge of committing the identity newly
 ;; created value but a second thread has updated it in the same time, then the first thread has to renew/retry the overall
 ;; process of calculating the identity new value but this time taking into account the current value of the identity as
@@ -171,7 +171,7 @@
 
 
 ;; Manipulating `Reference type`s
-;; There are 3 main operations for manipulating reference type values/state and for each, a corresponding function. Note that, as seen with
+;; There are 3 main operations for manipulating reference type values/states and for each, a corresponding function. Note that, as seen with
 ;; the Unified Update Model, these function calls have a `consistent` syntax and follow the same `pattern` :
 ;;  - Identity Initialization with the correct `reference type` via a `creation function`
 ;;    Pattern : (create-fn container)
@@ -190,8 +190,8 @@
 ;;                    |                 |   (send-off ...)        |                         |
 
 
-;; In the end, the choice for a concurrent implementation consists in reflecting and deciding what information to manage and what information
-;; to leave unmanaged.
+;; In the end, the choice for a concrete implementation consists in reflecting and deciding on which information to manage and which information
+;; to leave un-managed.
 
 
 

--- a/src/ch4/single.clj
+++ b/src/ch4/single.clj
@@ -94,15 +94,16 @@
 
 
 ;; There are two (2) dimensions involved when choosing the `right` reference type for the unified update model
-;;  - a notion of `scope` defining to which extent the change has to be applied
-;;  - a notion of `temporality` defining when the change has to be applied
+;;  - a notion of `scope` defining to which extent the change has to be applied also referred to as COORDINATION
+;;  - a notion of `temporality` and `context` defining when and in which context the change has to be applied also referred to
+;; as SYNCHRONIZATION
 
 
 ;; There are (2) scopes : atomic and transactional
 
 ;; ATOMIC SCOPE
 ;; It is used when a single `standalone` value is changed `independently` of all other stateful references within the system.
-;; It then does not require `coordination` because of this independence.
+;; It then does not require `coordination` because of this independence. We can also qualify it as an UNCOORDINATED operation.
 ;; The way it works is that given an identity and an update function, the latter is applied to the current value of the
 ;; former, eventually with arguments (seen earlier) to calculate the new value of the identity. If everything goes well,
 ;; this newly processed value will replace the current identity value.
@@ -117,6 +118,7 @@
 ;; It is used when multiple identities or stateful references have to change their values `together`. These multiple changes
 ;; have to happen altogether or not at all, hence the `transactional` qualification reminding us the terminology used in
 ;; RDBMS. Because of this `interdependence`, there needs to be a `coordination` when changing the stateful references values.
+;; That is why we can also qualify it as a COORDINATED operation.
 ;; In Clojure, this coordination is supported by an `emulation` of the very same techniques encountered in database management
 ;; systems when dealing with `updates` via `transactions`, to ensure all changes happen altogether or not at all.
 ;; Clojure's flavor is called `Software Transactional Memory` and it has almost the same ACI(D) properties except for the
@@ -137,3 +139,14 @@
 ;; restart but this time, it takes the values of the identities `updated outside` its scope as the initial value of these
 ;; identities and whose values conditions the `committing` or not of the new calculated values as the new values of the identity
 ;; system-wide.
+
+
+;; There are (2) kinds of `temporality/context` notions : Synchronous vs Asynchronous
+
+;; SYNCHRONOUS
+;; These operations are used when the caller's thread of execution has to block/wait for an exclusive access to a context in order
+;; to perform the operation.
+
+;; ASYNCHRONOUS
+;; Asynchronous operations, instead of blocking/waiting for an exclusive access to a context, spins off another thread to get
+;; a different context of its own for the execution. It does not block the caller's thread.

--- a/src/ch4/single.clj
+++ b/src/ch4/single.clj
@@ -55,3 +55,16 @@
 ;; values, a series of snapshots as if it were its `history` allowing to go back at a certain point in time
 ;; to a particular `state`, at will. Hence this `non-destructive` approach eases the process of changing state
 ;; because of the `immutability` nature of the data structure involved.
+
+
+
+;; ID AND STATE
+;; Clojure being a functional programming language embracing `immutability` as we have seen earlier, it is important
+;; to talk about `identity` and `state` and how they relate to each other to get a grasp of how it approaches
+;; and handles state management.
+;;
+;; an `identity` is a serie of `states` separated in time. It is represented by a `reference`, which is a mutable
+;; container containing a succession of immutable values (successive `states`)
+;;
+;; a `state` is a snapshot of an `identity's` value and it represents its value at that particular time. There is
+;; a notion of temporality involved here.

--- a/src/ch4/store.clj
+++ b/src/ch4/store.clj
@@ -121,3 +121,21 @@
 ;; updated because of the exception thrown by the validation function :
 ; @inventory
 ; => {:banana 6, :butter 2, :salt 0, :pizza 3, :juice 2}
+
+
+;; We have seen earlier the use of `validation functions` as a way to ensure that data within the system
+;; remain coherent if a change is applied to a reference type value, but also to prevent such operation from
+;; occuring if applying the new value may cause inconsistencies within the system.
+;; Here, we introduce `watches` as a way to get notified when the actual changes to the reference type value
+;; has been applied i.e the new value has been assigned to the reference type.
+;; `watches` are nothing more than an implementation of the `Observer pattern` in OOP but Clojure's FP flavor of
+;; it is simpler and easier to grasp and use.
+
+;; So what exactly is a `watch` : it simply is a function taking four parameters :
+;; (defn watch-fn [watch-key reference old-value new-value] ,,,)
+;; The last three parameters are self-explanatory. The `key` is used as a label or an ID that identifies the watch
+;; function among other watch functions attached to the reference type. In fact, you can attach more than one
+;; watch function to a reference and the `key` allows us to refer to a particular watch function in order
+;; to update (add-watch) or remove (remove-watch) it from the reference for example.
+;; Each time the value of the reference changes, i.e : old-value is different from new-value, the reference
+;; watch functions are triggered.

--- a/src/ch4/store.clj
+++ b/src/ch4/store.clj
@@ -1,0 +1,82 @@
+(ns ch4.store)
+
+;; Based on the ideas we developed from the previous explanations for our hypothetical inventory (in single.clj)
+;; let's first define our inventory
+(def inventory (atom {}))
+
+;; let's also define a utility function that we will use as a `validator` function for our inventory.
+;; A `validator` function is a function associated with a reference type and is called after the `data function` (via the `update function` call)
+;; is applied to a `reference type`'s value and BEFORE the `NEW` value calculated by the `update function` is committed as the NEW value of the reference.
+;; If the `validator` function returns `true`, then the new calculated value is committed to be the new value of the reference. Otherwise, the
+;; whole update function fails and the reference value is reverted to its prior value i.e the value before the `data function` has been applied.
+;; `validator` functions prevent data incoherence (in business parlance) e.g : we can not have a negative value as the number of items in the inventory.
+(defn no-negative-values?
+  "Checks that all item values within the inventory are positive"
+  [m]
+  (not-any? neg? (vals m)))
+
+;; let's now implement a function, taking as arguments a list of items, to initialize our inventory
+(defn init
+  "Initializes the inventory with a list of items"
+  [items]
+  ;; we first associate the validator function we defined earlier to our inventory
+  (set-validator! inventory no-negative-values?)
+  ;; we `update` the reference type value using the appropriate `update function`, here `swap!` since it's an atom
+  (swap! inventory merge items))
+
+;; let's also define another utility function allowing to check whether an item is in stock or not
+(defn in-stock?
+  "Checks whether the provided item in argument is in stock or not"
+  [item]
+  (let [counter (item @inventory)]
+    (and (pos? counter))))
+
+;; finally, let's define two functions for grabing and stocking an item from/in the store shelves
+(defn grab
+  "Grabs an item from the store shelves"
+  [item]
+  (swap! inventory update-in [item] dec))
+
+(defn stock
+  "Stocks an item in the store shelves"
+  [item]
+  (swap! inventory update-in [item] inc))
+
+;; if we define the following items
+;(def items {:banana 7
+;            :butter 2
+;            :salt 1
+;            :pizza 3
+;            :juice 3})
+;=> #'user/items
+
+;; and init the store shelves with these items using the `init` function defined earlier
+;(init items)
+;=> {:banana 7, :butter 2, :salt 1, :pizza 3, :juice 3}
+
+;; `grab`ing a banana from the store shelves would leave 6 bananas as shown in the following. The operation
+;; would have ensured any concurrent access by another thread to be shielded from partial updates or
+;; inconsistent data because we used the proper function, `swap!`, to update the reference value, which
+;; is an `atom` here
+;(grab :banana)
+;=> {:banana 6, :butter 2, :salt 1, :pizza 3, :juice 3}
+
+;; let's now consider, `grab`ing one salt item
+;(grab :salt)
+;=> {:banana 6, :butter 2, :salt 0, :pizza 3, :juice 3}
+
+;; we now have 0 salt items left in the inventory and if we try to `grab` another salt item, we get the following
+;; exception :
+;(grab :salt)
+;IllegalStateException Invalid reference state  clojure.lang.ARef.validate (ARef.java:33)
+
+;; we got this exception because before committing the newly computed value of the reference (via `grab`), which
+;; is -1 here, the underlying machinery triggered the `validator function` defined earlier (no-negative-values?)
+;; to check whether the value to be committed complies with the `rule(s)` spec'ed within. In our case, the validation
+;; function ensures that there is no negative values for items in the inventory.
+
+;; now, let's `stock` an item on the shelves, let's say another salt pack since we do not have any left. This would
+;; update the number of salt items by 1, giving us 1 salt pack
+;(stock :salt)
+;=> {:banana 6, :butter 2, :salt 1, :pizza 3, :juice 3}
+

--- a/src/ch4/store.clj
+++ b/src/ch4/store.clj
@@ -80,3 +80,44 @@
 ;(stock :salt)
 ;=> {:banana 6, :butter 2, :salt 1, :pizza 3, :juice 3}
 
+
+;; Now that we have everything set and tested, we can now re-work our `go-shopping-naive` function from single.clj
+(defn shop-for-item
+  "Shop for an item from the inventory and return the updated cart"
+  [cart item]
+  (if (grab item)
+    (conj cart item)
+    cart))
+
+(defn go-shopping
+  "Return the list of purchased items"
+  [shopping-list]
+  (reduce shop-for-item [] shopping-list))
+
+;; We even allowed ourselves to be `idiomatic` by having the `loop` replaced with a higher-level construct :
+;; `reduce`.
+;; Given the example inventory we had earlier :
+; (init items)
+; => {:banana 7, :butter 2, :salt 1, :pizza 3, :juice 3}
+
+;; shopping for banana, salt and juice would give us our cart content updated with these items :
+; (go-shopping [:banana :salt :juice])
+; => [:banana :salt :juice]
+
+;; and listing what is available within the inventory would give us the content minus the items
+;; we put in our cart :
+; @inventory
+; => {:banana 6, :butter 2, :salt 0, :pizza 3, :juice 2}
+
+;; At this stage, trying to grab another salt item would give us the following exception :
+; (go-shopping [:salt])
+; IllegalStateException Invalid reference state  clojure.lang.ARef.validate (ARef.java:33)
+
+;; our validation function triggered its logic to ensure that there are no items whose count is negative,
+;; in the inventory. Since we did not have any salt item left (count = 0), the validation-function did not
+;; allow the operation of grabbing one from the inventory to occur.
+
+;; at this stage, if we check again the content of the inventory, we see that the previous content has not been
+;; updated because of the exception thrown by the validation function :
+; @inventory
+; => {:banana 6, :butter 2, :salt 0, :pizza 3, :juice 2}


### PR DESCRIPTION
This PR implements the concepts and illustrations used in _Chapter 4 : State, Identity and Change_ regarding :

- Clojure's approach to concurrency
- Reference types as mutable state container in Clojure : `atom`, `ref`, `var`, `agent` and the _Unified Update Model_
- Clojure's _Software Transactional Memory_ (STM)
- Atomic (in isolation)/Coordinated, synchronous/asynchronous 
- ...